### PR TITLE
Trying to read file size

### DIFF
--- a/kraken.php
+++ b/kraken.php
@@ -1025,6 +1025,12 @@ EOD;
 			$optimize_main_image = !empty( $settings['optimize_main_image'] ); 
 
 			$file = get_attached_file( $id );
+			// Ensure file exists on this server.
+			if ( ! file_exists( $file ) ) {
+				print('No file found on server');
+				return false;
+			}	
+			
 			$original_size = filesize( $file );
 
 			// handle the case where file does not exist


### PR DESCRIPTION
Can we add a check if the file exists first before trying to read the file size? 
We often do DB syncs between environments, without copying all the uploads, just add an .htaccess rewrite, and this poses too many warnings of the filesize failing because not being able to find the file locally.